### PR TITLE
haproxy improves

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ service:
   name: rabbitmq # unique
   image: rabbitmq:3-management-alpine # image
   network: bridge # docker network - it will be created if it does not exists
-  ports:  # haproxy port mapping: <external_port>|<internal_port>|<tcp|http>|round_robin
+  ports:  # haproxy port mapping
+          #   <external_port>:[internal_port]:<tcp|http>:[round_robin (default)|leastconn]
+          # to define a range on `external_port`, leave `internal_port` blank
+          #   - 5000-5100::tcp:round_robin
+          # range on `internal_port` is not supported 
     - 5672:5672:tcp:round_robin
     - 80:15672:http:round_robin
   resources:

--- a/lib/mkit.rb
+++ b/lib/mkit.rb
@@ -110,6 +110,9 @@ module MKIt
       srv.deploy_network
       srv.update_status!
     }
+    # daemontools would eventually start haproxy; systemd does not.
+    # so, restart here.
+    MKIt::HAProxy.restart
   end
 
   def self.startup(options: {})

--- a/lib/mkit/app/controllers/services_controller.rb
+++ b/lib/mkit/app/controllers/services_controller.rb
@@ -41,9 +41,6 @@ class ServicesController < MKIt::Server
       srv.update!(yaml.to_o)
     end
     format_response(srv)
-  rescue MKIt::BaseException => e
-    MKItLogger.debug e
-    error e.error_code, e.message
   end
 
   # curl -X DELETE localhost:4567/services/1
@@ -62,9 +59,6 @@ class ServicesController < MKIt::Server
       srv = Service.create(yaml.to_o)
     end
     format_response(srv)
-  rescue MKIt::BaseException => e
-    MKItLogger.debug e
-    error e.error_code, e.message
   end
 
   #
@@ -84,4 +78,3 @@ class ServicesController < MKIt::Server
     format_response(srv)
   end
 end
-

--- a/lib/mkit/app/mkit_server.rb
+++ b/lib/mkit/app/mkit_server.rb
@@ -3,6 +3,18 @@ require 'mkit/exceptions'
 module MKIt
   class Server < Sinatra::Base
     set :default_content_type, :json
-    # set :dump_errors, false
+    set :dump_errors, true
+    set :show_exceptions, false
+    set :raise_errors, false
+
+    error MKIt::BaseException do |e|
+      MKItLogger.debug e
+      error e.error_code, e.message
+    end
+
+    error do |e|
+      MKItLogger.debug e
+      error 500, e.message
+    end
   end
 end

--- a/lib/mkit/app/model/service.rb
+++ b/lib/mkit/app/model/service.rb
@@ -9,11 +9,7 @@ require 'mkit/status'
 require 'mkit/utils'
 require 'mkit/ctypes'
 require 'mkit/app/model/pool'
-require 'mkit/app/model/service'
-require 'mkit/app/model/pod'
 require 'mkit/app/model/dns_host'
-require 'mkit/app/helpers/erb_helper'
-require 'mkit/app/helpers/docker_helper'
 require 'mkit/app/helpers/haproxy'
 
 #
@@ -199,19 +195,6 @@ class Service < ActiveRecord::Base
   #
   # ha proxy configs & template
   #
-  def public_ports
-    self.service_port.each.map{|p| p.external_port}.uniq
-  end
-
-  def ports_by_external(external_port)
-    self.service_port.where('external_port = ?', external_port)
-  end
-
-  def ports_mode_by_external(external_port)
-    ports = self.service_port.where('external_port = ?', external_port).first
-    ports.mode if ports
-  end
-
   def update_proxy
     MkitJob.publish(topic: :update_proxy_config, application_id: self.id, data: proxy_config)
   end

--- a/lib/mkit/app/model/service_port.rb
+++ b/lib/mkit/app/model/service_port.rb
@@ -1,7 +1,10 @@
 require 'mkit/app/model/service'
+require 'mkit/exceptions'
 
 class ServicePort < ActiveRecord::Base
   belongs_to :service
+
+  CONFIG_EXPRESSION=/^(.*?):(.*?):(tcp|http):(.*?)$/
 
   def self.create(service:, config:)
     sp = ServicePort.new(service: service, version: service.version)
@@ -9,22 +12,36 @@ class ServicePort < ActiveRecord::Base
     sp
   end
 
-  # haproxy support for port range - leave src blank
+  # haproxy support for port range - leave dest blank
   # service:
   #   ports:
-  #     # src:dest:tcp|http:load-balancing
+  #     # src:dest:tcp|http:round_robin|leastconn
   #     - 5532:5432:tcp:round_robin
+  #     - 5532-6000::tcp:round_robin
   # model:
   #  service_ports:
   #     - external: 5432
   #       internal: 5432
   #       mode: tcp|http
-  #       load_bal:
+  #       load_bal: round_robin
   def parse_config(config)
-    ports = config.split(':')
-    self.external_port = ports[0]
-    self.internal_port = ports[1]
-    self.mode = ports[2]
-    self.load_bal = ports[3]
+    ports = config.match(CONFIG_EXPRESSION)
+    raise MKIt::InvalidPortsConfiguration.new("no match with config expression $#{CONFIG_EXPRESSION}") if ports.nil?
+
+    self.external_port = ports[1]
+    self.internal_port = ports[2]
+    self.mode = ports[3]
+    self.load_bal = ports[4]
+  end
+
+  def load_balance
+    case self.load_bal
+    when /^round_robin$/
+      "roundrobin"
+    when /^leastconn$/
+      "leastconn"
+    else
+      "roundrobin"
+    end
   end
 end

--- a/lib/mkit/app/templates/haproxy/xapp_haproxy.cfg.erb
+++ b/lib/mkit/app/templates/haproxy/xapp_haproxy.cfg.erb
@@ -1,30 +1,27 @@
 #
 # MKIt generated file
 #
-<% public_ports.each { |external_port|%>
+<% service_port.each { |port|%>
 #
-# start <%=name%>-<%=external_port%>
+# start <%=name%>-<%=port.external_port%>
 #
-frontend <%=name%>-<%=external_port%>-front
-  bind <%=lease.ip%>:<%=external_port%>
-  mode <%=ports_mode_by_external(external_port)%>
+frontend <%=name%>-<%=port.external_port%>-front
+  bind <%=lease.ip%>:<%=port.external_port%>
+  mode <%=port.mode%>
   #
-  use_backend <%=name%>-<%=external_port%>-back
+  use_backend <%=name%>-<%=port.external_port%>-back
 
-backend <%=name%>-<%=external_port%>-back
-   mode <%=ports_mode_by_external(external_port)%>
-   #balance leastconn
-   balance  roundrobin
- <%if ports_mode_by_external(external_port) == 'http'%>
-   option httpclose
-   option forwardfor
-   cookie JSESSIONID prefix
- <%end%>
-<%ports_by_external(external_port).each { |port| %>
-   <%port.service.pod.each { | pod | %>
-   server <%=pod.name%>  <%=pod.ip%>:<%=port.internal_port%> <%if port.mode == 'http'%>cookie A<%end%>  check<%}%><%}%>
-# 
-# end of <%=name%>-<%=external_port%>
+backend <%=name%>-<%=port.external_port%>-back
+  mode <%=port.mode%>
+  balance <%=port.load_balance%>
+ <%if port.mode == 'http'%>
+  option httpclose
+  option forwardfor
+  cookie JSESSIONID prefix
+ <%end%><%port.service.pod.each { | pod | %>
+  server <%=pod.name%>  <%=pod.ip%><%unless port.internal_port.nil? || port.internal_port.empty? then%><%=":#{port.internal_port}"%> <%if port.mode == 'http'%>cookie A<%end%> check<%end%>
+  <%}%>
+#
+# end of <%=name%>-<%=port.external_port%>
 #
 <%}%>
-

--- a/lib/mkit/exceptions.rb
+++ b/lib/mkit/exceptions.rb
@@ -17,6 +17,11 @@ module MKIt
       super(400, message)
     end
   end
+  class InvalidPortsConfiguration < BaseException
+    def initialize(message = nil)
+      super(400, message)
+    end
+  end
   class ServiceNotFoundException < StandardError; end
   class PodNotFoundException     < StandardError; end
   class AppAlreadyDeployedException < StandardError; end

--- a/lib/mkit/version.rb
+++ b/lib/mkit/version.rb
@@ -1,4 +1,4 @@
 module MKIt
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end
 

--- a/mkit.gemspec
+++ b/mkit.gemspec
@@ -6,12 +6,12 @@ require "mkit/version"
 
 Gem::Specification.new do |s|
         s.name         = 'mkit'
-        s.summary      = 'micro kubernets'
+        s.summary      = 'Micro Kubernets on Ruby'
         s.bindir       = 'bin'
-        s.homepage     = 'http://vars.pt'
+        s.homepage     = 'https://github.com/valexsantos/mkit'
         s.license      = 'Apache-2.0'
         s.rubyforge_project = ''
-        s.description  = 'micro kubernets impl'
+        s.description  = 'Micro k8s on Ruby - a simple tool to deploy containers to mimic a (very) minimalistic k8 cluster with a nice REST API'
         # s.require_paths = ["."]
         s.author      = 'Vasco Santos'
         s.email        = ['valexsantos@gmail.com']


### PR DESCRIPTION
* add `port range` support to `haproxy` template
* fix `haproxy` `systemd` startup issue after a reboot - `haproxy` restart forced after all interfaces are created 
* error handling - `show_exceptions` false
* added controllers default error handler