### PR TITLE
initial service logs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Commands:
 
 ps         show services status (alias for status)
 status     show services status
+logs       service logs
 start      start service
 stop       stop service
 restart    restart service

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Commands:
 
 ps         show services status (alias for status)
 status     show services status
-logs       service logs
+logs       prints service logs
 start      start service
 stop       stop service
 restart    restart service

--- a/bin/mkitc
+++ b/bin/mkitc
@@ -51,7 +51,7 @@ class MKItClient
         args: [
           { name: 'id', mandatory: true }
         ],
-        help: 'service logs',
+        help: 'prints service logs',
         usage: ['<service_id_or_name>'],
         request: { verb: :get, uri: '/services/<%=id%>/logs' }
       },

--- a/bin/mkitc
+++ b/bin/mkitc
@@ -47,6 +47,15 @@ class MKItClient
         request: { verb: :get, uri: '/services' }
       },
       {
+        cmd: 'logs',
+        args: [
+          { name: 'id', mandatory: true }
+        ],
+        help: 'service logs',
+        usage: ['<service_id_or_name>'],
+        request: { verb: :get, uri: '/services/<%=id%>/logs' }
+      },
+      {
         cmd: 'start',
         args: [
           { name: 'id', mandatory: true }

--- a/lib/mkit/app/controllers/services_controller.rb
+++ b/lib/mkit/app/controllers/services_controller.rb
@@ -31,6 +31,11 @@ class ServicesController < MKIt::Server
     resp
   end
 
+  get '/services/:id/logs' do
+    srv = find_by_id_or_name
+    srv.log
+  end
+
   # curl -X PUT localhost:4567/services/1  -F "file=@mkit/samples/mkit.yml"
   put '/services/:id' do
     srv = find_by_id_or_name

--- a/lib/mkit/app/helpers/docker_helper.rb
+++ b/lib/mkit/app/helpers/docker_helper.rb
@@ -32,6 +32,13 @@ module MKIt
     end
 
     #
+    # logs
+    #
+    def logs(instance_id)
+      `docker logs -n 20 #{instance_id}`
+    end
+
+    #
     # network
     #
 

--- a/lib/mkit/app/helpers/services_helper.rb
+++ b/lib/mkit/app/helpers/services_helper.rb
@@ -8,14 +8,10 @@ module MKIt
       table.head = %w[id name addr ports pods status]
       if data.respond_to? 'each'
         data.each do |srv|
-          ports = srv.service_port&.each.map { |p| "#{p.mode}/#{p.external_port}" }.join(',')
-          pods = srv.pod.each.map { |p| p.name.to_s }.join(' ')
-          table.rows << [srv.id, srv.name, srv.lease&.ip, ports, pods, srv.status]
+          table.rows << build_table_row(srv)
         end
       else
-        ports = data.service_port&.each.map { |p| "#{p.mode}/#{p.external_port}" }.join(',')
-        pods = data.pod.each.map { |p| p.name.to_s }.join(' ')
-        table.rows << [data.id, data.name, data.lease&.ip, ports, pods, data.status]
+        table.rows << build_table_row(data)
       end
       table.to_s
     end
@@ -25,6 +21,12 @@ module MKIt
       srv ||= Service.find_by_name(params[:id])
       error 404, "Couldn't find Service '#{params[:id]}'\n" unless srv
       srv
+    end
+
+    def build_table_row(data)
+      ports = data.service_port&.each.map { |p| "#{p.mode}/#{p.external_port}" }.join(',')
+      pods = data.pod.each.map { |p| p.name.to_s }.join(' ')
+      [data.id, data.name, data.lease&.ip, ports, pods, data.status]
     end
   end
 end

--- a/lib/mkit/app/model/service.rb
+++ b/lib/mkit/app/model/service.rb
@@ -131,7 +131,7 @@ class Service < ActiveRecord::Base
   end
 
   def create_pods_network
-    create_network(self.pods_network) if !network_exists?(self.pods_network)
+    create_network(self.pods_network) unless network_exists?(self.pods_network)
   end
 
   def deploy_network
@@ -237,6 +237,15 @@ class Service < ActiveRecord::Base
     }
   end
 
+  def log
+    out = ""
+    self.pod.each { |p|
+      out << "<<<< %s | %s >>>>\n" % [self.name, p.name]
+      puts logs(p.name)
+      out << logs(p.name)
+    }
+    out
+  end
   def as_json(options = {})
     srv = super
     a=[:pod, :volume, :service_config, :service_port]


### PR DESCRIPTION
Initial service logs support. Prints service pod(s) logs (last 20 lines)

```
$ mkitc logs
MKItc: Invalid parameters found.

Usage: mkitc logs <service_id_or_name>

service logs
```
