### PR TITLE
feat: added log options - clear, timestamps

### DIFF
--- a/lib/mkit/app/controllers/services_controller.rb
+++ b/lib/mkit/app/controllers/services_controller.rb
@@ -43,12 +43,14 @@ class ServicesController < MKIt::Server
       srv.log
     else
       pod = find_srv_pod_by_id_or_name(srv)
-      options_parameter = build_options_hash(params: params, options: [:nr_lines, :pods, :follow])
+      options_parameter = build_options_hash(params: params, options: [
+        :nr_lines, :pods, :follow, :details, :timestamps, :clear
+      ])
       request.websocket do |ws|
         listener = nil
         ws.onopen do
           settings.sockets << ws
-          ws.send("<<<< %s | %s >>>>\n" % [srv.name, srv.pod.first.name])
+          ws.send("<<<< %s | %s >>>>\n" % [srv.name, pod.name])
           listener = MKIt::DockerLogListener.new(pod, ws, options: options_parameter)
           settings.listeners << listener
           listener.register

--- a/lib/mkit/app/helpers/docker_helper.rb
+++ b/lib/mkit/app/helpers/docker_helper.rb
@@ -38,6 +38,14 @@ module MKIt
       `docker logs -n 20 #{instance_id}`
     end
 
+    def logfile(instance_id)
+      `docker inspect --format='{{.LogPath}}' #{instance_id}`
+    end
+
+    def clear_logs(instance_id)
+      `echo "" > #{logfile(instance_id)}`
+    end
+
     #
     # network
     #

--- a/lib/mkit/app/helpers/docker_helper.rb
+++ b/lib/mkit/app/helpers/docker_helper.rb
@@ -43,7 +43,7 @@ module MKIt
     end
 
     def clear_logs(instance_id)
-      `echo "" > #{logfile(instance_id)}`
+      `echo > #{logfile(instance_id)}`
     end
 
     #

--- a/lib/mkit/app/helpers/services_helper.rb
+++ b/lib/mkit/app/helpers/services_helper.rb
@@ -26,10 +26,10 @@ module MKIt
     def find_srv_pod_by_id_or_name(srv)
       if params[:pod_id]
         pod = srv.find_pod_by_id_or_name(params[:pod_id])
-        error 404, "Service pod not found." unless pod
       else
         pod = srv.pod.first
       end
+      error 404, "Service pod not found." unless pod
       pod
     end
 

--- a/lib/mkit/app/model/service.rb
+++ b/lib/mkit/app/model/service.rb
@@ -271,7 +271,7 @@ class Service < ActiveRecord::Base
     end
     srv['ports'] = []
     self.service_port.each { |p|
-      "#{p.internal_port}:#{p.external_port}:#{p.mode}:#{p.load_bal}".tap { |x|
+      "#{p.external_port}:#{p.internal_port}:#{p.mode}:#{p.load_bal}".tap { |x|
         if p.ssl == 'true'
           x << ':ssl'
           if !p.crt.nil? && p.crt != MKIt::Utils.proxy_cert

--- a/lib/mkit/client/commands.yaml
+++ b/lib/mkit/client/commands.yaml
@@ -264,15 +264,6 @@
       type: flag
       switch:
         - "-d"
-    - name: clear
-      help:
-        - -c
-        - Clear log file
-      mandatory: false
-      param: "<%=true%>"
-      type: flag
-      switch:
-        - "-c"
 - cmd: version
   help: prints mkit client and server version
   request:

--- a/lib/mkit/client/commands.yaml
+++ b/lib/mkit/client/commands.yaml
@@ -245,6 +245,34 @@
       type: option
       switch:
         - "-n"
+    - name: timestamps
+      help:
+        - -t
+        - Show timestamps
+      mandatory: false
+      param: "<%=true%>"
+      type: flag
+      switch:
+        - "-t"
+        - "--timestamps"
+    - name: details
+      help:
+        - -d
+        - Show extra details
+      mandatory: false
+      param: "<%=true%>"
+      type: flag
+      switch:
+        - "-d"
+    - name: clear
+      help:
+        - -c
+        - Clear log file
+      mandatory: false
+      param: "<%=true%>"
+      type: flag
+      switch:
+        - "-c"
 - cmd: version
   help: prints mkit client and server version
   request:

--- a/lib/mkit/pods/docker_log_listener.rb
+++ b/lib/mkit/pods/docker_log_listener.rb
@@ -1,15 +1,25 @@
 require "mkit/cmd/shell_client"
+require "mkit/app/helpers/docker_helper"
 
 module MKIt
   class DockerLogListener < MKIt::ShellClient
 
+    include DockerHelper
+
     def initialize(pod, ws, options: {})
+      if options[:clear]
+        clear_logs(pod.name)
+      end
       @pod = pod
       @ws = ws
       command = "docker logs"
       command += " -f" if options[:follow] == 'true'
       command += " -n #{options[:nr_lines]}" if options[:nr_lines]
       command += " -n 10" unless options[:nr_lines]
+      command += " -t" if options[:timestamps] == 'true'
+      command += " --since #{options[:since]}" if options[:since]
+      command += " --until #{options[:until]}" if options[:until]
+      command += " --details" if options[:details] == 'true'
       command += " #{@pod.name}"
       super(command: command)
     end

--- a/lib/mkit/version.rb
+++ b/lib/mkit/version.rb
@@ -1,4 +1,4 @@
 module MKIt
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end
 


### PR DESCRIPTION
## Description

* feat: added log options - clear, timestamps
* fix: get service ingress port order

### Details

```
$ mkit logs
MKIt: Missing mandatory parameter: id

Usage: mkit logs <service_id_or_name> [-p <pod_id>] [-f] [-n <lines>]

view service logs

Options:
id           Service id or name
-p <pod_id>  Show logs for specified pod (default first)
-f           Follow log output
-n <string>  Number of lines to show from the end of the logs (default 10)
-t           Show timestamps
-d           Show extra details
```
