### PR TITLE
feat - introducing new ingress configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ create       create new service
 update       update service
 get          print service configuration
 rm           remove service
+migrate      migrate local service definition to the new schema version
 exec         execute a command in a running pod
 logs         view service logs
 version      prints mkit client and server version

--- a/README.md
+++ b/README.md
@@ -127,18 +127,52 @@ service:
   name: rabbitmq # unique. Available on internal DNS as 'rabbitmq'
   image: rabbitmq:3-management-alpine # image
   network: bridge # docker network - it will be created if it does not exists
-  ports:  # haproxy port mapping
-          #   <external_port>:[internal_port]:<tcp|http>:[round_robin (default)|leastconn]
-          # to define a range on `external_port`, leave `internal_port` blank
-          #   - 5000-5100::tcp:round_robin
-          #   range on `internal_port` is not supported
-          # ssl suport
-          #   <external_port>:[internal_port]:<tcp|http>:round_robin|leastconn[:ssl[,<cert.pem>(mkit.pem default)>]]
-          #   e.g.
-          #  - 443:80:http:round_robin:ssl # uses mkitd default crt file (mkit.pem)
-          #  - 443:80:http:round_robin:ssl,/etc/pki/foo.pem # custom crt file full path
-    - 5672:5672:tcp:round_robin
-    - 80:15672:http:round_robin
+  ingress:
+    # ingress configuration
+    # see https://docs.haproxy.org/3.1/configuration.html
+    frontend: # frontend section
+      - name: http-in-ssl # frontend name - must be unique
+        options: # frontend global section options
+          - option httpclose
+          - option forwardfor
+        bind:
+          port: 443 # to define a range (e.g. 8000-8080), backend `port` must be blank
+          ssl: true # ssl support - default is false
+          mode: http # tcp|http
+          cert: /etc/ssl/certs/server.crt # if empty uses mkit default crt file (mkit.pem)
+          options: # frontend bind section options
+            - accept-proxy
+            - transparent
+            - defer-accept
+        default_backend: admin # backend to use - must point to a backend name
+      - name: http-in
+        bind:
+          port: 80
+          mode: http
+        default_backend: admin
+      - name: server-in
+        bind:
+          port: 5672
+          mode: tcp
+        default_backend: server
+    backend: # backend section
+      - name: admin # backend name - must be unique
+        balance: round_robin # round_robin|least_conn - default is round_robin
+        options: # backend global section options
+          - option httpclose
+          - option forwardfor
+          - cookie JSESSIONID prefix
+        bind:
+          port: 15672 # if this backend is used by a frontend with a range port, this port must be blank
+          mode: http
+          options: # backend bind section options
+            - cookie A
+            - check
+      - name: server
+        balance: round_robin
+        bind:
+          port: 5672
+          mode: tcp
   resources:
     min_replicas: 1 # default value. Pods will be available on internal DNS as '<service_name>.internal'
     max_replicas: 1 # default value
@@ -163,9 +197,9 @@ Usage: mkitd [options]
     -b bind                          specify bind address (e.g. 0.0.0.0)
     -e env                           set the environment (default is development)
     -o addr                          alias for '-b' option
-        --no-ssl                     disable ssl - use http for local server. (default is https)
-        --ssl-key-file PATH          Path to private key (default mkit internal)
-        --ssl-cert-file PATH         Path to certificate (default mkit internal)
+    --no-ssl                         disable ssl - use http for local server. (default is https)
+    --ssl-key-file PATH              Path to private key (default mkit internal)
+    --ssl-cert-file PATH             Path to certificate (default mkit internal)
 ```
 
 There's also samples for [systemd](samples/systemd) and [daemontools](samples/daemontools) as well for some miscellaneous [spps](samples/apps).

--- a/db/migrate/004_create_ingress.rb
+++ b/db/migrate/004_create_ingress.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateIngress < ActiveRecord::Migration[5.1]
+  def up
+    create_table :ingresses do |t|
+      t.string :service_id
+      t.string :version
+      t.timestamp :created_at
+      t.timestamp :updated_at
+    end
+  end
+end

--- a/db/migrate/005_create_frontend.rb
+++ b/db/migrate/005_create_frontend.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateFrontend < ActiveRecord::Migration[5.1]
+  def up
+    create_table :frontends do |t|
+      t.string :ingress_id
+      t.string :name
+      t.string :mode
+      t.string :port
+      t.string :ssl
+      t.string :crt
+      t.text :options, default: '[]'
+      t.text :bind_options, default: '[]'
+      t.text :default_backend
+      t.string :version
+      t.timestamp :created_at
+      t.timestamp :updated_at
+    end
+  end
+end

--- a/db/migrate/006_create_backend.rb
+++ b/db/migrate/006_create_backend.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateBackend < ActiveRecord::Migration[5.1]
+  def up
+    create_table :backends do |t|
+      t.string :ingress_id
+      t.string :name
+      t.string :mode
+      t.string :load_bal
+      t.string :port
+      t.text :options, default: '[]'
+      t.text :bind_options, default: '[]'
+      t.string :version
+      t.timestamp :created_at
+      t.timestamp :updated_at
+    end
+  end
+end

--- a/db/migrate/007_migrate_schema.rb
+++ b/db/migrate/007_migrate_schema.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class MigrateSchema < ActiveRecord::Migration[5.1]
+
+  #
+  # migrate the schema from service_ports to ingress
+  #
+  def up
+    Service.all.each do |service|
+      puts "####### #{service} #######"
+      ingress_config = service_ports_to_ingress service.service_port
+      ingress = Ingress.create(service, ingress_config)
+      service.ingress = ingress
+      service.service_port.destroy_all
+    end
+  end
+
+  def service_ports_to_ingress(ports)
+    ingress = { frontend: [], backend: [] }
+
+    ports.each do |port|
+      frontend = {
+        name: "frontend-#{port.external_port}",
+        bind: {
+          port: port.external_port,
+          mode: port.mode
+        },
+        options: [],
+        default_backend: "backend-#{port.external_port}"
+      }
+
+      if port.ssl.start_with?('true')
+        frontend[:bind][:ssl] = true
+        frontend[:bind][:cert] = port.crt
+      end
+
+      backend = {
+        name: "backend-#{port.external_port}",
+        bind: {
+          port: port.internal_port,
+          mode: port.mode
+        },
+        balance: port.load_bal
+      }
+
+      if port.mode == 'http'
+        a= [
+          'option httpclose',
+          'option forwardfor',
+          'cookie JSESSIONID prefix'
+        ]
+        backend[:options] = a
+        backend[:bind][:options] = [ 'cookie A check' ]
+      end
+      ingress[:frontend] << frontend
+      ingress[:backend] << backend
+    end
+
+    hash = ingress.remove_symbols_from_keys
+    hash
+  end
+end

--- a/db/migrate/007_migrate_schema.rb
+++ b/db/migrate/007_migrate_schema.rb
@@ -7,10 +7,8 @@ class MigrateSchema < ActiveRecord::Migration[5.1]
   #
   def up
     Service.all.each do |service|
-      puts "####### #{service} #######"
       ingress_config = service_ports_to_ingress service.service_port
-      ingress = Ingress.create(service, ingress_config)
-      service.ingress = ingress
+      service.ingress = Ingress.create(ingress_config)
       service.service_port.destroy_all
     end
   end

--- a/db/migrate/007_migrate_schema.rb
+++ b/db/migrate/007_migrate_schema.rb
@@ -54,7 +54,6 @@ class MigrateSchema < ActiveRecord::Migration[5.1]
       ingress[:backend] << backend
     end
 
-    hash = ingress.remove_symbols_from_keys
-    hash
+    ingress.remove_symbols_from_keys
   end
 end

--- a/lib/mkit/app/controllers/services_controller.rb
+++ b/lib/mkit/app/controllers/services_controller.rb
@@ -3,12 +3,14 @@
 require 'mkit/app/model/service'
 require 'mkit/app/helpers/services_helper'
 require 'mkit/app/helpers/params_helper'
+require 'mkit/app/helpers/migrations_helper'
 require 'mkit/pods/docker_log_listener'
 require 'mkit/pods/docker_exec_command'
 
 class ServicesController < MKIt::Server
   helpers MKIt::ServicesHelper
   helpers MKIt::ParamsHelper
+  helpers MKIt::MigrationsHelper
 
   # curl localhost:4567/services
   get '/services' do
@@ -98,6 +100,16 @@ class ServicesController < MKIt::Server
       srv = Service.create(yaml.to_o)
     end
     format_response(srv)
+  end
+
+  post '/services/migrate' do
+    srv = 'no file'
+    if params[:file]
+      tempfile = params[:file][:tempfile]
+      yaml = YAML.safe_load(tempfile.read)
+      srv = migrate_service(yaml).to_yaml
+    end
+    srv
   end
 
   #

--- a/lib/mkit/app/helpers/migrations_helper.rb
+++ b/lib/mkit/app/helpers/migrations_helper.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'mkit/utils'
+
+module MKIt
+  module MigrationsHelper
+
+    def migrate_service(yaml)
+      puts yaml
+      yaml['service']['ingress'] = ports_to_ingress(yaml['service']['ports'])
+
+      yaml['service'].delete('ports')
+      yaml
+    end
+
+    def ports_to_ingress(ports)
+      ingress = { frontend: [], backend: [] }
+
+      ports.each_with_index do |port_config, index|
+        match = port_config.match(/^(.*?):(.*?):(tcp|http):(.*?)($|:ssl$|:ssl,(.+))$/)
+        next unless match
+
+        external_port, internal_port, mode, load_bal, ssl, cert = match.captures
+
+        frontend = {
+          name: "frontend-#{external_port}",
+          bind: {
+            port: external_port.to_i,
+            ssl: ssl.start_with?(':ssl'),
+            cert: cert || '/etc/ssl/certs/server.crt'
+          },
+          mode: mode,
+          options: [],
+          default_backend: "backend-#{external_port}"
+        }
+
+        backend = {
+          name: "backend-#{external_port}",
+          bind: {
+            port: internal_port.to_i,
+            mode: mode
+          },
+          balance: load_bal
+        }
+
+        if mode == 'http'
+          a= [
+            'option httpclose',
+            'option forwardfor',
+            'cookie JSESSIONID prefix'
+          ]
+          backend[:options] = a
+          backend[:bind][:options] = [ 'cookie A check' ]
+        end
+        ingress[:frontend] << frontend
+        ingress[:backend] << backend
+      end
+
+      puts ingress
+      ingress.remove_symbols_from_keys
+    end
+
+    def remove_symbols_from_keys(hash)
+      hash.each_with_object({}) do |(k, v), new_hash|
+        new_key = k.to_s
+        new_value = if v.is_a?(Hash)
+                      remove_symbols_from_keys(v)
+                    elsif v.is_a?(Array)
+                      v.map { |item| item.is_a?(Hash) ? remove_symbols_from_keys(item) : item }
+                    else
+                      v
+                    end
+        new_hash[new_key] = new_value
+      end
+    end
+  end
+end

--- a/lib/mkit/app/helpers/migrations_helper.rb
+++ b/lib/mkit/app/helpers/migrations_helper.rb
@@ -25,19 +25,22 @@ module MKIt
         frontend = {
           name: "frontend-#{external_port}",
           bind: {
-            port: external_port.to_i,
-            ssl: ssl.start_with?(':ssl'),
-            cert: cert || '/etc/ssl/certs/server.crt'
+            port: external_port
           },
           mode: mode,
           options: [],
           default_backend: "backend-#{external_port}"
         }
 
+        if ssl.start_with?(':ssl')
+          frontend[:bind][:ssl] = true
+          frontend[:bind][:cert] = cert
+        end
+
         backend = {
           name: "backend-#{external_port}",
           bind: {
-            port: internal_port.to_i,
+            port: internal_port,
             mode: mode
           },
           balance: load_bal
@@ -56,22 +59,8 @@ module MKIt
         ingress[:backend] << backend
       end
 
-      puts ingress
       ingress.remove_symbols_from_keys
     end
 
-    def remove_symbols_from_keys(hash)
-      hash.each_with_object({}) do |(k, v), new_hash|
-        new_key = k.to_s
-        new_value = if v.is_a?(Hash)
-                      remove_symbols_from_keys(v)
-                    elsif v.is_a?(Array)
-                      v.map { |item| item.is_a?(Hash) ? remove_symbols_from_keys(item) : item }
-                    else
-                      v
-                    end
-        new_hash[new_key] = new_value
-      end
-    end
   end
 end

--- a/lib/mkit/app/helpers/migrations_helper.rb
+++ b/lib/mkit/app/helpers/migrations_helper.rb
@@ -6,9 +6,7 @@ module MKIt
   module MigrationsHelper
 
     def migrate_service(yaml)
-      puts yaml
       yaml['service']['ingress'] = ports_to_ingress(yaml['service']['ports'])
-
       yaml['service'].delete('ports')
       yaml
     end
@@ -24,11 +22,11 @@ module MKIt
 
         frontend = {
           name: "frontend-#{external_port}",
-          bind: {
-            port: external_port
-          },
-          mode: mode,
           options: [],
+          bind: {
+            port: external_port,
+            mode: mode
+          },
           default_backend: "backend-#{external_port}"
         }
 

--- a/lib/mkit/app/helpers/migrations_helper.rb
+++ b/lib/mkit/app/helpers/migrations_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'mkit/utils'
-
 module MKIt
   module MigrationsHelper
 

--- a/lib/mkit/app/helpers/services_helper.rb
+++ b/lib/mkit/app/helpers/services_helper.rb
@@ -34,27 +34,16 @@ module MKIt
     end
 
     def build_table_row(data)
-      ports = data.service_port&.each.map { |p| build_port(p) }.join(',')
+      ports = data.ingress.frontends&.each.map { |f| build_port(f) }.join(',')
       pods = data.pod.each.map { |p| p.name.to_s }.join(' ')
       [data.id, data.name, data.lease&.ip, ports, pods, data.status]
     end
 
     def build_port(p)
-      case p.mode
-      when 'http'
-        if p.ssl?
-          "#{p.mode}s/#{p.external_port}"
-        else
-          "#{p.mode}/#{p.external_port}"
-        end
-      when 'tcp'
-        if p.ssl?
-          "s#{p.mode}/#{p.external_port}"
-        else
-          "#{p.mode}/#{p.external_port}"
-        end
+      if p.ssl?
+        "#{p.mode}s/#{p.port}"
       else
-        "#{p.mode}/#{p.external_port}"
+        "#{p.mode}/#{p.port}"
       end
     end
   end

--- a/lib/mkit/app/model/backend.rb
+++ b/lib/mkit/app/model/backend.rb
@@ -27,7 +27,7 @@ class Backend  < ActiveRecord::Base
     case self.load_bal
     when /^round_robin$/
       "roundrobin"
-    when /^leastconn$/
+    when /^least_conn$/
       "leastconn"
     else
       "roundrobin"
@@ -35,7 +35,7 @@ class Backend  < ActiveRecord::Base
   end
 
   def to_h(options = {})
-    {
+    hash = {
       name: self.name,
       bind: {
         port: self.port,
@@ -44,6 +44,11 @@ class Backend  < ActiveRecord::Base
       },
       options: self.options,
       balance: self.load_bal
-    }.remove_symbols_from_keys
+    }
+
+    if self.port.nil? || self.port.empty?
+      hash[:bind].delete(:port)
+    end
+    hash.remove_symbols_from_keys
   end
 end

--- a/lib/mkit/app/model/backend.rb
+++ b/lib/mkit/app/model/backend.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Backend  < ActiveRecord::Base
+  belongs_to :ingress
+  serialize :options, JSON
+  serialize :bind_options, JSON
+
+  def self.create(yaml)
+    validate(yaml)
+    backend = Backend.new
+    backend.name = yaml["name"]
+    backend.port = yaml["bind"]["port"] if yaml["bind"]["port"]
+    backend.mode = yaml["bind"]["mode"] if yaml["bind"]["mode"]
+    backend.options = yaml["options"] if yaml["options"]
+    backend.load_bal = yaml["balance"] if yaml["balance"]
+    backend.bind_options = yaml["bind"]["options"] if yaml["bind"]["options"]
+    backend
+  end
+
+  def self.validate(yaml)
+    raise "name is mandatory" unless yaml["name"]
+    raise "bind is mandatory" unless yaml["bind"]
+    raise "mode is mandatory" unless yaml["bind"]["mode"]
+  end
+
+  def load_balance
+    case self.load_bal
+    when /^round_robin$/
+      "roundrobin"
+    when /^leastconn$/
+      "leastconn"
+    else
+      "roundrobin"
+    end
+  end
+
+  def to_h(options = {})
+    {
+      name: self.name,
+      bind: {
+        port: self.port,
+        mode: self.mode,
+        options: self.bind_options
+      },
+      options: self.options,
+      balance: self.load_bal
+    }.remove_symbols_from_keys
+  end
+end

--- a/lib/mkit/app/model/backend.rb
+++ b/lib/mkit/app/model/backend.rb
@@ -18,12 +18,12 @@ class Backend  < ActiveRecord::Base
   end
 
   def self.validate(yaml)
-    raise "name is mandatory" unless yaml["name"]
-    raise "bind is mandatory" unless yaml["bind"]
-    raise "mode is mandatory" unless yaml["bind"]["mode"]
-    raise "mode must match tcp|http" unless yaml["bind"]["mode"] =~ /^(tcp|http)$/
+    raise_bad_configuration "name is mandatory" unless yaml["name"]
+    raise_bad_configuration "bind is mandatory" unless yaml["bind"]
+    raise_bad_configuration "mode is mandatory" unless yaml["bind"]["mode"]
+    raise_bad_configuration "mode must match tcp|http" unless yaml["bind"]["mode"] =~ /^(tcp|http)$/
     if yaml["balance"]
-      raise "balance must match round_robin|least_conn" unless yaml["balance"] =~ /^(round_robin|least_conn)$/
+      raise_bad_configuration "balance must match round_robin|least_conn" unless yaml["balance"] =~ /^(round_robin|least_conn)$/
     end
   end
 

--- a/lib/mkit/app/model/backend.rb
+++ b/lib/mkit/app/model/backend.rb
@@ -21,6 +21,10 @@ class Backend  < ActiveRecord::Base
     raise "name is mandatory" unless yaml["name"]
     raise "bind is mandatory" unless yaml["bind"]
     raise "mode is mandatory" unless yaml["bind"]["mode"]
+    raise "mode must match tcp|http" unless yaml["bind"]["mode"] =~ /^(tcp|http)$/
+    if yaml["balance"]
+      raise "balance must match round_robin|least_conn" unless yaml["balance"] =~ /^(round_robin|least_conn)$/
+    end
   end
 
   def load_balance
@@ -37,13 +41,13 @@ class Backend  < ActiveRecord::Base
   def to_h(options = {})
     hash = {
       name: self.name,
+      balance: self.load_bal,
+      options: self.options,
       bind: {
         port: self.port,
         mode: self.mode,
         options: self.bind_options
-      },
-      options: self.options,
-      balance: self.load_bal
+      }
     }
 
     if self.port.nil? || self.port.empty?

--- a/lib/mkit/app/model/frontend.rb
+++ b/lib/mkit/app/model/frontend.rb
@@ -16,7 +16,7 @@ class Frontend  < ActiveRecord::Base
     frontend.mode = yaml["bind"]["mode"] if yaml["bind"]["mode"]
     frontend.bind_options = yaml["bind"]["options"] if yaml["bind"]["options"]
     frontend.options = yaml["options"] if yaml["options"]
-    frontend.default_backend = yaml["default_backend"]
+    frontend.default_backend = yaml["use_backend"]
 
     has_ssl = !yaml["bind"]["ssl"].nil? && yaml["bind"]["ssl"].to_s.start_with?('true')
     frontend.ssl = has_ssl ? 'true' : 'false'
@@ -28,11 +28,12 @@ class Frontend  < ActiveRecord::Base
   end
 
   def self.validate(yaml)
-    raise "name is mandatory" unless yaml["name"]
-    raise "default_backend is mandatory" unless yaml["default_backend"]
-    raise "bind is mandatory" unless yaml["bind"]
-    raise "mode is mandatory" unless yaml["bind"]["mode"]
-    raise "mode must match tcp|http" unless yaml["bind"]["mode"] =~ /^(tcp|http)$/
+    raise_bad_configuration "name is mandatory" unless yaml["name"]
+    raise_bad_configuration "default_backend is mandatory" unless yaml["default_backend"]
+    raise_bad_configuration "bind is mandatory" unless yaml["bind"]
+    raise_bad_configuration "mode is mandatory" unless yaml["bind"]["mode"]
+    raise_bad_configuration "frontend port is mandatory" unless yaml["bind"]["port"]
+    raise_bad_configuration "mode must match tcp|http" unless yaml["bind"]["mode"] =~ /^(tcp|http)$/
   end
 
   def ssl?

--- a/lib/mkit/app/model/frontend.rb
+++ b/lib/mkit/app/model/frontend.rb
@@ -32,6 +32,7 @@ class Frontend  < ActiveRecord::Base
     raise "default_backend is mandatory" unless yaml["default_backend"]
     raise "bind is mandatory" unless yaml["bind"]
     raise "mode is mandatory" unless yaml["bind"]["mode"]
+    raise "mode must match tcp|http" unless yaml["bind"]["mode"] =~ /^(tcp|http)$/
   end
 
   def ssl?
@@ -41,6 +42,7 @@ class Frontend  < ActiveRecord::Base
   def to_h(options = {})
     hash = {
       name: self.name,
+      options: self.options,
       bind: {
         port: self.port,
         mode: self.mode,
@@ -48,7 +50,6 @@ class Frontend  < ActiveRecord::Base
         cert: self.ssl? ? self.crt : nil,
         options: self.bind_options
       },
-      options: self.options,
       default_backend: self.default_backend
     }
 

--- a/lib/mkit/app/model/frontend.rb
+++ b/lib/mkit/app/model/frontend.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'mkit/exceptions'
+
+class Frontend  < ActiveRecord::Base
+  belongs_to :ingress
+  serialize :options, JSON
+  serialize :bind_options, JSON
+  has_one :backend
+
+  def self.create(yaml)
+    validate(yaml)
+    frontend = Frontend.new
+
+    frontend.name = yaml["name"]
+    frontend.port = yaml["bind"]["port"] if yaml["bind"]["port"]
+    frontend.mode = yaml["bind"]["mode"] if yaml["bind"]["mode"]
+    frontend.ssl = !yaml["bind"]["ssl"].nil? && yaml["bind"]["ssl"].to_s.start_with?('true') ? 'true':'false'
+    frontend.crt = yaml["bind"]["cert"].nil? ? MKIt::Utils.proxy_cert : yaml["bind"]["cert"]
+    frontend.bind_options = yaml["bind"]["options"] if yaml["bind"]["options"]
+    frontend.options = yaml["options"] if yaml["options"]
+    frontend.default_backend = yaml["default_backend"]
+    frontend
+  end
+
+  def self.validate(yaml)
+    raise "name is mandatory" unless yaml["name"]
+    raise "default_backend is mandatory" unless yaml["default_backend"]
+    raise "bind is mandatory" unless yaml["bind"]
+    raise "mode is mandatory" unless yaml["bind"]["mode"]
+  end
+
+  def ssl?
+    self.ssl == 'true'
+  end
+
+  def to_h(options = {})
+    {
+      name: self.name,
+      bind: {
+        port: self.port,
+        mode: self.mode,
+        ssl: self.ssl,
+        crt: self.crt,
+        options: self.bind_options
+      },
+      options: self.options,
+      default_backend: self.default_backend
+    }.remove_symbols_from_keys
+  end
+end

--- a/lib/mkit/app/model/ingress.rb
+++ b/lib/mkit/app/model/ingress.rb
@@ -7,10 +7,9 @@ class Ingress < ActiveRecord::Base
   has_many :frontends, dependent: :destroy
   has_many :backends, dependent: :destroy
 
-  def self.create(service, yaml)
+  def self.create(yaml)
     validate(yaml)
     ingress = Ingress.new
-    ingress.service = service
 
     yaml["backend"].each do |back|
       ingress.backends << Backend.create(back)
@@ -83,7 +82,7 @@ class Ingress < ActiveRecord::Base
     yaml["frontend"].each do |front|
       if front["bind"]["port"] =~ /^\d+-\d+$/
         referred_backend = yaml["backend"].find { |back| back["name"] == front["default_backend"] }
-        raise "Frontend port range '#{front["bind"]["port"]}' must have an empty backend port" unless referred_backend && (referred_backend["bind"]["port"].nil? || referred_backend["bind"]["port"].empty?)
+        raise "Frontend port range '#{front["bind"]["port"]}' must have an empty backend port" unless referred_backend && (referred_backend["bind"]["port"].nil?)
       end
     end
 

--- a/lib/mkit/app/model/ingress.rb
+++ b/lib/mkit/app/model/ingress.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'mkit/app/model/backend'
+require 'mkit/app/model/frontend'
+
+class Ingress < ActiveRecord::Base
+  belongs_to :service
+  has_many :frontends, dependent: :destroy
+  has_many :backends, dependent: :destroy
+
+  def self.create(service, yaml)
+    validate(yaml)
+    ingress = Ingress.new
+    ingress.service = service
+
+    yaml["backend"].each do |back|
+      ingress.backends << Backend.create(back)
+    end
+
+    yaml["frontend"].each do |front|
+      ingress.frontends << Frontend.create(front)
+    end
+    ingress
+  end
+
+  def self.validate(yaml)
+    frontend_names = []
+    frontend_ports = []
+
+    # must have at least one frontend and one backend
+    raise "At least one frontend is mandatory" unless yaml["frontend"]
+    raise "At least one backend is mandatory" unless yaml["backend"]
+    # frontend name is mandatory
+    yaml["frontend"].each { |front| raise "Frontend name is mandatory" unless front["name"] }
+    # backend name is mandatory
+    yaml["backend"].each { |back| raise "Backend name is mandatory" unless back["name"] }
+    # frontend must point to a valid backend name - backend names list
+    backend_names = yaml["backend"].map { |back| back["name"] }
+
+    # frontend validation
+    yaml["frontend"].each do |front|
+      # name is mandatory
+      raise "Frontend name is mandatory" unless front["name"]
+      # frontend name must be unique
+      if frontend_names.include?(front["name"])
+        raise "Frontend name '#{front["name"]}' must be unique"
+      end
+      frontend_names << front["name"]
+
+      # bind and mode are mandatory, port is not
+      raise "Frontend bind and mode are mandatory" unless front["bind"] && front["bind"]["mode"]
+
+      # port must be unique
+      if frontend_ports.include?(front["bind"]["port"])
+        raise "Frontend port '#{front["bind"]["port"]}' must be unique"
+      end
+      frontend_ports << front["bind"]["port"]
+
+      # default_backend must point to a valid backend name
+      unless backend_names.include?(front["default_backend"])
+        raise "Frontend default_backend '#{front["default_backend"]}' must point to a valid backend name"
+      end
+    end
+
+    # backend validation
+    backend_names.each do |name|
+      if backend_names.count(name) > 1
+        raise "Backend name '#{name}' must be unique"
+      end
+    end
+    # each backend must point to a valid frontend default_backend
+    frontend_default_backends = yaml["frontend"].map { |front| front["default_backend"] }
+    yaml["backend"].each do |back|
+      unless frontend_default_backends.include?(back["name"])
+        raise "Backend '#{back["name"]}' must be referenced by at least one frontend default_backend"
+      end
+    end
+
+    true
+  end
+
+  def to_h(options)
+    {
+      frontend: self.frontends.map { |front| front.to_h },
+      backend: self.backends.map { |back| back.to_h }
+    }.remove_symbols_from_keys
+  end
+end

--- a/lib/mkit/app/model/pod.rb
+++ b/lib/mkit/app/model/pod.rb
@@ -58,13 +58,7 @@ class Pod < ActiveRecord::Base
   end
 
   def start
-    # if self.instance.nil?
-    #   docker_run = parse
-    #   MKItLogger.info("deploying docker pod, cmd [#{docker_run}]")
-    #   create_instance(docker_run)
-    # else
-      start_instance(self.name) unless instance.State.Running
-    # end
+    start_instance(self.name) unless instance.State.Running
   end
 
   def stop

--- a/lib/mkit/app/model/pod.rb
+++ b/lib/mkit/app/model/pod.rb
@@ -58,13 +58,13 @@ class Pod < ActiveRecord::Base
   end
 
   def start
-    if self.instance.nil?
-      docker_run = parse
-      MKItLogger.info("deploying docker pod, cmd [#{docker_run}]")
-      create_instance(docker_run)
-    else
+    # if self.instance.nil?
+    #   docker_run = parse
+    #   MKItLogger.info("deploying docker pod, cmd [#{docker_run}]")
+    #   create_instance(docker_run)
+    # else
       start_instance(self.name) unless instance.State.Running
-    end
+    # end
   end
 
   def stop
@@ -78,12 +78,12 @@ class Pod < ActiveRecord::Base
   end
 
   def clean_up
-    begin
-      remove_instance(self.name) unless self.instance.nil?
-    rescue => e
-      MKItLogger.warn(e)
-    end
-    MkitJob.publish(topic: :pod_destroyed, service_id: self.service.id, data: {pod_id: self.id})
+    # stop and destroy pod
+    MkitJob.publish(topic: :destroy_pod_saga,
+                    service_id: self.service.id,
+                    pod_id: self.id,
+                    data: {pod_name: self.name}
+    )
   end
 
   def to_h

--- a/lib/mkit/app/model/service.rb
+++ b/lib/mkit/app/model/service.rb
@@ -268,20 +268,8 @@ class Service < ActiveRecord::Base
         srv['pods'] << p.to_h
       }
     end
-    # services will be migrated on db migration startup
-    srv['ports'] = []
-    self.service_port.each { |p|
-      "#{p.external_port}:#{p.internal_port}:#{p.mode}:#{p.load_bal}".tap { |x|
-        if p.ssl == 'true'
-          x << ':ssl'
-          if !p.crt.nil? && p.crt != MKIt::Utils.proxy_cert
-            x << ":#{p.crt}"
-          end
-        end
-        srv['ports'] << x
-      }
-    }
 
+    # ingress
     srv['ingress'] = self.ingress.to_h(options)
 
     srv['resources'] = {}

--- a/lib/mkit/app/model/service.rb
+++ b/lib/mkit/app/model/service.rb
@@ -93,7 +93,7 @@ class Service < ActiveRecord::Base
     self.create_pods_network
 
     # haproxy config
-    self.ingress = Ingress.create(self, config.ingress)
+    self.ingress = Ingress.create(config.ingress)
 
     # volumes
     self.volume = []

--- a/lib/mkit/app/model/service_config.rb
+++ b/lib/mkit/app/model/service_config.rb
@@ -7,7 +7,7 @@ class ServiceConfig < ActiveRecord::Base
     ServiceConfig.new(
       service: service,
       key: key,
-      value: !value.nil? && (value.is_a?(TrueClass) || value.is_a?(FalseClass)) ? String(value) : value,
+      value: value,
       version: service.version,
       ctype: ctype
     )

--- a/lib/mkit/app/model/service_config.rb
+++ b/lib/mkit/app/model/service_config.rb
@@ -7,7 +7,7 @@ class ServiceConfig < ActiveRecord::Base
     ServiceConfig.new(
       service: service,
       key: key,
-      value: value,
+      value: !value.nil? && (value.is_a?(TrueClass) || value.is_a?(FalseClass)) ? String(value) : value,
       version: service.version,
       ctype: ctype
     )

--- a/lib/mkit/app/model/service_port.rb
+++ b/lib/mkit/app/model/service_port.rb
@@ -34,7 +34,6 @@ class ServicePort < ActiveRecord::Base
     ports = config.match(CONFIG_EXPRESSION)
     raise MKIt::InvalidPortsConfiguration.new("no match with config expression $#{CONFIG_EXPRESSION}") if ports.nil?
 
-    puts ports
     self.external_port = ports[1]
     self.internal_port = ports[2]
     self.mode = ports[3]

--- a/lib/mkit/app/templates/haproxy/0000_defaults.cfg
+++ b/lib/mkit/app/templates/haproxy/0000_defaults.cfg
@@ -1,8 +1,8 @@
 global
         log 127.0.0.1   local2
         maxconn 4096
-        user nobody
-        group nobody
+        user haproxy
+        group haproxy
 
 defaults
     log                     global

--- a/lib/mkit/app/templates/haproxy/app_haproxy.cfg.erb
+++ b/lib/mkit/app/templates/haproxy/app_haproxy.cfg.erb
@@ -10,7 +10,7 @@
 frontend  <%=name%>-<%=fe.name%>-front
   bind <%=lease.ip%>:<%=fe.port%> <%=if fe.ssl? then "ssl crt #{fe.crt}" end%> <%=fe.bind_options.join(' ')%>
   mode <%=fe.mode%>
-  <%=be.options.join("\n  ")%>
+  <%=fe.options.join("\n  ")%>
 
   use_backend <%=name%>-<%=fe.default_backend%>-back
 <%}%>

--- a/lib/mkit/app/templates/haproxy/app_haproxy.cfg.erb
+++ b/lib/mkit/app/templates/haproxy/app_haproxy.cfg.erb
@@ -1,0 +1,28 @@
+#
+# MKIt generated file
+# Service <%=name%>
+#
+
+#
+# frontends
+#
+<% ingress.frontends.each { |fe|%>
+frontend  <%=name%>-<%=fe.name%>-front
+  bind <%=lease.ip%>:<%=fe.port%> <%=if fe.ssl? then "ssl crt #{fe.crt}" end%> <%=fe.bind_options.join(' ')%>
+  mode <%=fe.mode%>
+  <%=be.options.join("\n  ")%>
+
+  use_backend <%=name%>-<%=fe.default_backend%>-back
+<%}%>
+#
+# backends
+#
+<% ingress.backends.each { |be|%>
+backend <%=name%>-<%=be.name%>-back
+  mode <%=be.mode%>
+  balance <%=be.load_balance%>
+  <%=be.options.join("\n  ")%>
+<%pod.each { | pod | %>
+  server <%=pod.name%>  <%=pod.ip%><%unless be.port.nil? || be.port.empty? then%><%=":#{be.port}"%> <%=be.bind_options.join(' ')%> <%end%>
+<%}%>
+<%}%>

--- a/lib/mkit/client/commands.yaml
+++ b/lib/mkit/client/commands.yaml
@@ -159,6 +159,19 @@
   request:
     verb: delete
     uri: "/services/<%=id%>"
+- cmd: migrate
+  usage:
+    - "<service.yaml>"
+  help: migrate service to new definition
+  args:
+    - name: file
+      help:
+        - file
+        - Service definition
+      mandatory: true
+  request:
+    verb: post
+    uri: "/services/migrate"
 - cmd: exec
   usage:
     - "<service_id_or_name> [options] -- <command> [args...]"

--- a/lib/mkit/client/commands.yaml
+++ b/lib/mkit/client/commands.yaml
@@ -162,7 +162,7 @@
 - cmd: migrate
   usage:
     - "<service.yaml>"
-  help: migrate service to new definition
+  help: migrate local service definition to the new schema version
   args:
     - name: file
       help:

--- a/lib/mkit/config/environment.rb
+++ b/lib/mkit/config/environment.rb
@@ -6,6 +6,7 @@ require 'sinatra'
 
 require_relative 'initializers/001_hash'
 require_relative 'initializers/002_openstruct'
+require_relative 'initializers/003_custom_exceptions'
 
 SOCKET_PATH = File.expand_path('/tmp/app.sock')
 

--- a/lib/mkit/config/initializers/001_hash.rb
+++ b/lib/mkit/config/initializers/001_hash.rb
@@ -8,4 +8,18 @@ class Hash
       memo[key] = val.is_a?(Hash) ? val.to_os : val
     end
   end
+
+  def remove_symbols_from_keys
+    self.each_with_object({}) do |(k, v), new_hash|
+      new_key = k.to_s
+      new_value = if v.is_a?(Hash)
+                    v.remove_symbols_from_keys
+                  elsif v.is_a?(Array)
+                    v.map { |item| item.is_a?(Hash) ? item.remove_symbols_from_keys : item }
+                  else
+                    v
+                  end
+      new_hash[new_key] = new_value
+    end
+  end
 end

--- a/lib/mkit/config/initializers/003_custom_exceptions.rb
+++ b/lib/mkit/config/initializers/003_custom_exceptions.rb
@@ -1,0 +1,10 @@
+# Load custom exceptions
+require 'mkit/exceptions'
+
+module CustomExceptions
+  def raise_bad_configuration(message)
+    raise MKIt::InvalidConfigurationException, "MKIt :: Invalid Configuration :: #{message}"
+  end
+end
+
+Object.include(CustomExceptions)

--- a/lib/mkit/ctypes.rb
+++ b/lib/mkit/ctypes.rb
@@ -25,7 +25,7 @@ module MKIt
     module Templates
       DOCKER_RUN = 'docker/docker_run.sh'
       DOCKER_BUILD = 'docker/docker_build.sh'
-      HAPROXY = 'haproxy/xapp_haproxy.cfg'
+      HAPROXY = 'haproxy/app_haproxy.cfg'
       HAPROXY_DEFAULTS = 'haproxy/0000_defaults.cfg'
     end
 end

--- a/lib/mkit/exceptions.rb
+++ b/lib/mkit/exceptions.rb
@@ -22,7 +22,19 @@ module MKIt
       super(400, message)
     end
   end
-  class ServiceNotFoundException < StandardError; end
+
+  class ServiceNotFoundException < BaseException
+    def initialize(message = nil)
+      super(404, message)
+    end
+  end
+
+  class InvalidConfigurationException < BaseException
+    def initialize(message = nil)
+      super(400, message)
+    end
+  end
+
   class PodNotFoundException     < StandardError; end
   class AppAlreadyDeployedException < StandardError; end
   class InvalidPortMappingTypeException < StandardError; end

--- a/lib/mkit/pods/docker_listener.rb
+++ b/lib/mkit/pods/docker_listener.rb
@@ -6,7 +6,7 @@ require "mkit/cmd/shell_client"
 # https://docs.docker.com/engine/reference/commandline/events
 require 'mkit/app/helpers/docker_helper'
 module MKIt
-class StopThread < RuntimeError; end
+  class StopThread < RuntimeError; end
 
   class DockerListener
     include MKIt::DockerHelper
@@ -67,22 +67,27 @@ class StopThread < RuntimeError; end
         end
       when :network
         pod_id = msg.Actor.Attributes.container
-        inspect = inspect_instance(pod_id).to_o
-        pod_name = inspect.Name[1..]
-        pod = Pod.find_by(name: pod_name)
-        unless pod.nil?
-          case action
-          when :connect
-            MKItLogger.info("docker network #{action} received: #{msg} for pod #{pod_name}")
-            pod.update_ip
-            pod.save
-          when :disconnect
-            MKItLogger.debug("  #{type} #{action} <<NOOP / TODO>>")
+        inspect = inspect_instance(pod_id)
+        unless inspect.nil?
+          inspect = inspect.to_o
+          pod_name = inspect.Name[1..]
+          pod = Pod.find_by(name: pod_name)
+          unless pod.nil?
+            case action
+            when :connect
+              MKItLogger.info("docker network #{action} received: #{msg} for pod #{pod_name}")
+              pod.update_ip
+              pod.save
+            when :disconnect
+              MKItLogger.debug("  #{type} #{action} <<NOOP / TODO>>")
+            else
+              MKItLogger.debug("  #{type} #{action} <<TODO>>")
+            end
           else
-            MKItLogger.debug("  #{type} #{action} <<TODO>>")
+            MKItLogger.warn("docker <<#{type}>> <#{action}> received: #{msg}. But I don't know anything about pod #{pod_id}/#{pod_name}")
           end
         else
-          MKItLogger.warn("docker <<#{type}>> <#{action}> received: #{msg}. But I don't know anything about pod #{pod_id}/#{pod_name}")
+            MKItLogger.warn("docker <<#{type}>> <#{action}> received: #{msg}. But I don't know anything about pod #{pod_id}")
         end
       else
         MKItLogger.info("\t#{type} #{action} <<unknown>>")

--- a/lib/mkit/sagas/destroy_pod_saga.rb
+++ b/lib/mkit/sagas/destroy_pod_saga.rb
@@ -1,0 +1,37 @@
+require 'mkit/app/helpers/docker_helper'
+
+module MKIt
+  class DestroyPodSaga < ASaga
+    include MKIt::DockerHelper
+
+    def topics
+      %w{destroy_pod_saga}
+    end
+
+    #
+    # destroy_pod_saga:
+    #
+    # payload:
+    #  * pod_name
+    #  * pod.id
+    #
+    # triggers
+    #  * pod_destroyed?
+    #
+    def do_the(job)
+      MKItLogger.info("#{self.class} <#{job.topic}> #{job.inspect}....")
+
+      begin
+        remove_instance(job.data['pod_name'])
+      rescue => e
+        MKItLogger.warn(e)
+      end
+
+      # MkitJob.publish(topic: :pod_destroyed,
+      #                 service_id: job.service_id,
+      #                 data: {pod_name: job.data['pod_name']}
+      # )
+
+    end
+  end
+end

--- a/lib/mkit/sagas/destroy_pod_saga.rb
+++ b/lib/mkit/sagas/destroy_pod_saga.rb
@@ -27,11 +27,6 @@ module MKIt
         MKItLogger.warn(e)
       end
 
-      # MkitJob.publish(topic: :pod_destroyed,
-      #                 service_id: job.service_id,
-      #                 data: {pod_name: job.data['pod_name']}
-      # )
-
     end
   end
 end

--- a/lib/mkit/sagas/saga_manager.rb
+++ b/lib/mkit/sagas/saga_manager.rb
@@ -1,10 +1,12 @@
 require 'mkit/sagas/asaga'
 require 'mkit/sagas/create_pod_saga'
+require 'mkit/sagas/destroy_pod_saga'
 
 module MKIt
   class SagaManager
     def self.register_workers
       CreatePodSaga.new
+      DestroyPodSaga.new
     end
   end
 end

--- a/lib/mkit/version.rb
+++ b/lib/mkit/version.rb
@@ -1,4 +1,4 @@
 module MKIt
-  VERSION = "0.14.0"
+  VERSION = "0.10.0"
 end
 

--- a/lib/mkit/version.rb
+++ b/lib/mkit/version.rb
@@ -1,4 +1,4 @@
 module MKIt
-  VERSION = "0.9.1"
+  VERSION = "0.14.0"
 end
 

--- a/lib/mkit/workers/pod_worker.rb
+++ b/lib/mkit/workers/pod_worker.rb
@@ -28,7 +28,9 @@ module MKIt
           MkitJob.publish(topic: :update_proxy_config, service_id: job.service_id)
         end
       when :pod_ip_updated
-        MkitJob.publish(topic: :update_proxy_config, service_id: job.service_id)
+        if Service.exists?(job.service_id)
+          MkitJob.publish(topic: :update_proxy_config, service_id: job.service_id)
+        end
       else
         MKItLogger.info("#{self.class} <<TODO>> job #{job.inspect}....")
       end

--- a/lib/mkit/workers/service_worker.rb
+++ b/lib/mkit/workers/service_worker.rb
@@ -1,3 +1,5 @@
+
+
 module MKIt
   class ServiceWorker < AWorker
 

--- a/samples/apps/httpbin.yml
+++ b/samples/apps/httpbin.yml
@@ -1,0 +1,46 @@
+---
+service:
+  name: httpbin
+  image: mccutchen/go-httpbin
+  command: 
+  network: bridge
+  ingress:
+    frontend:
+    - name: http-in-ssl
+      bind:
+        port: 443
+        mode: http
+        ssl: true
+        options: []
+      options: []
+      default_backend: server
+    - name: http-in
+      bind:
+        port: 80
+        mode: http
+        ssl: false
+        options:
+        - accept-proxy
+        - transparent
+        - defer-accept
+      options: []
+      default_backend: server
+    backend:
+    - name: server
+      bind:
+        port: 8080
+        mode: http
+        options:
+        - cookie A check
+      options:
+      - option httpclose
+      - option forwardfor
+      - cookie JSESSIONID prefix
+      balance: round_robin
+  resources:
+    min_replicas: 1
+    max_replicas: 1
+  volumes: []
+  environment:
+    LOG4J_LEVEL: WARN
+    LOGGING_LEVEL_ROOT: WARN

--- a/samples/apps/httpbin.yml
+++ b/samples/apps/httpbin.yml
@@ -6,37 +6,37 @@ service:
   network: bridge
   ingress:
     frontend:
-    - name: http-in-ssl
-      bind:
-        port: 443
-        mode: http
-        ssl: true
-        options: []
-      options: []
-      default_backend: server
-    - name: http-in
-      bind:
-        port: 80
-        mode: http
-        ssl: false
+      - name: http-in-ssl
         options:
-        - accept-proxy
-        - transparent
-        - defer-accept
-      options: []
-      default_backend: server
+          - option httpclose
+          - option forwardfor
+        bind:
+          port: 443
+          mode: http
+          ssl: true
+          options:
+            - accept-proxy
+            - transparent
+            - defer-accept
+        default_backend: server
+      - name: http-in
+        options:
+          - option forwardfor
+        bind:
+          port: 80
+          mode: http
+        default_backend: server
     backend:
     - name: server
+      balance: round_robin
+      options:
+      - cookie JSESSIONID prefix
       bind:
         port: 8080
         mode: http
         options:
-        - cookie A check
-      options:
-      - option httpclose
-      - option forwardfor
-      - cookie JSESSIONID prefix
-      balance: round_robin
+        - cookie A
+        - check
   resources:
     min_replicas: 1
     max_replicas: 1

--- a/samples/apps/kafka-cluster.yml
+++ b/samples/apps/kafka-cluster.yml
@@ -1,21 +1,31 @@
-#
+---
 service:
   name: kafka-cluster
   network: kafka-cluster
   image: confluentinc/cp-kafka:7.1.6
-  ports:
-    - 9092:9092:tcp:round_robin
   volumes:
-    - docker://kafka_cluster_secrets:/etc/kafka/secrets
-    - docker://kafka_cluster_data:/var/lib/kafka/data
+  - docker://kafka_cluster_secrets:/etc/kafka/secrets
+  - docker://kafka_cluster_data:/var/lib/kafka/data
   environment:
     KAFKA_BROKER_ID: 1
     KAFKA_ZOOKEEPER_CONNECT: kafka-zookeeper:2181
-    KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-cluster:9092
     KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
-      # KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://kafka-schema-registry
     KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-
+  ingress:
+    frontend:
+    - name: frontend-9092
+      options: []
+      bind:
+        port: '9092'
+        mode: tcp
+      default_backend: backend-9092
+    backend:
+    - name: backend-9092
+      bind:
+        port: '9092'
+        mode: tcp
+      balance: round_robin

--- a/samples/apps/kafka-magic.yml
+++ b/samples/apps/kafka-magic.yml
@@ -1,16 +1,33 @@
-#
+---
 service:
   name: kafka-magic
   network: kafka-cluster
-  ports:
-    - 80:80:http:round_robin
   image: digitsy/kafka-magic
   environment:
-    KMAGIC_ALLOW_TOPIC_DELETE: "true"
-    KMAGIC_ALLOW_SCHEMA_DELETE: "true"
-    KMAGIC_CONFIG_STORE_TYPE: "file"
-    KMAGIC_CONFIG_STORE_CONNECTION: "Data Source=/config/KafkaMagicConfig.db;"
-    KMAGIC_CONFIG_ENCRYPTION_KEY: "123456"
+    KMAGIC_ALLOW_TOPIC_DELETE: 'true'
+    KMAGIC_ALLOW_SCHEMA_DELETE: 'true'
+    KMAGIC_CONFIG_STORE_TYPE: file
+    KMAGIC_CONFIG_STORE_CONNECTION: Data Source=/config/KafkaMagicConfig.db;
+    KMAGIC_CONFIG_ENCRYPTION_KEY: '123456'
   volumes:
-    - docker://kafka_magic_config:/config
-
+  - docker://kafka_magic_config:/config
+  ingress:
+    frontend:
+    - name: frontend-80
+      options: []
+      bind:
+        port: '80'
+        mode: http
+      default_backend: backend-80
+    backend:
+    - name: backend-80
+      bind:
+        port: '80'
+        mode: http
+        options:
+        - cookie A check
+      balance: round_robin
+      options:
+      - option httpclose
+      - option forwardfor
+      - cookie JSESSIONID prefix

--- a/samples/apps/kafka-zookeeper.yml
+++ b/samples/apps/kafka-zookeeper.yml
@@ -1,15 +1,26 @@
-#
+---
 service:
   name: kafka-zookeeper
   image: confluentinc/cp-zookeeper:7.1.6
   network: kafka-cluster
-  ports:
-    - 2181:2181:tcp:round_robin
   volumes:
-    - docker://kafka_zookeeper_secrets:/etc/zookeeper/secrets
-    - docker://kafka_zookeeper_data:/var/lib/zookeeper/data
-    - docker://kafka_zookeeper_log:/var/lib/zookeeper/log
+  - docker://kafka_zookeeper_secrets:/etc/zookeeper/secrets
+  - docker://kafka_zookeeper_data:/var/lib/zookeeper/data
+  - docker://kafka_zookeeper_log:/var/lib/zookeeper/log
   environment:
     ZOOKEEPER_CLIENT_PORT: 2181
     ZOOKEEPER_TICK_TIME: 2000
-
+  ingress:
+    frontend:
+    - name: frontend-2181
+      options: []
+      bind:
+        port: '2181'
+        mode: tcp
+      default_backend: backend-2181
+    backend:
+    - name: backend-2181
+      bind:
+        port: '2181'
+        mode: tcp
+      balance: round_robin

--- a/samples/apps/minio.yml
+++ b/samples/apps/minio.yml
@@ -1,16 +1,42 @@
-#
+---
 service:
   name: minio
   image: minio/minio
   command: server /data --console-address ":9001"
   network: bridge
-  ports:
-    - 9001:9001:http:round_robin
-    - 9000:9000:tcp:round_robin
   environment:
     MINIO_ACCESS_KEY: minio
     MINIO_SECRET_KEY: minio123
   volumes:
-    - docker://minio_data:/data
-    #- /tmp/minio_data:/data
-
+  - docker://minio_data:/data
+  ingress:
+    frontend:
+    - name: frontend-9001
+      options: []
+      bind:
+        port: '9001'
+        mode: http
+      default_backend: backend-9001
+    - name: frontend-9000
+      options: []
+      bind:
+        port: '9000'
+        mode: tcp
+      default_backend: backend-9000
+    backend:
+    - name: backend-9001
+      bind:
+        port: '9001'
+        mode: http
+        options:
+        - cookie A check
+      balance: round_robin
+      options:
+      - option httpclose
+      - option forwardfor
+      - cookie JSESSIONID prefix
+    - name: backend-9000
+      bind:
+        port: '9000'
+        mode: tcp
+      balance: round_robin

--- a/samples/apps/mongo.yml
+++ b/samples/apps/mongo.yml
@@ -1,9 +1,20 @@
-#
+---
 service:
   name: mongo
   image: mongo:4.0
   command: "--smallfiles"
   network: bridge
-  ports:
-    - 27017:27017:tcp:round_robin
-
+  ingress:
+    frontend:
+    - name: frontend-27017
+      options: []
+      bind:
+        port: '27017'
+        mode: tcp
+      default_backend: backend-27017
+    backend:
+    - name: backend-27017
+      bind:
+        port: '27017'
+        mode: tcp
+      balance: round_robin

--- a/samples/apps/nexus.yml
+++ b/samples/apps/nexus.yml
@@ -1,14 +1,49 @@
-#
+---
 service:
   name: nexus
   image: sonatype/nexus3
   network: bridge
-  ports:
-    - 80:8081:http:round_robin
-    - 443:8081:http:round_robin:ssl
   resources:
     max_replicas: 1
     min_replicas: 1
   volumes:
-    - docker://nexus_data:/nexus-data
-
+  - docker://nexus_data:/nexus-data
+  ingress:
+    frontend:
+    - name: frontend-80
+      options: []
+      bind:
+        port: '80'
+        mode: http
+      default_backend: backend-80
+    - name: frontend-443
+      options: []
+      bind:
+        port: '443'
+        mode: http
+        ssl: true
+        cert: 
+      default_backend: backend-443
+    backend:
+    - name: backend-80
+      bind:
+        port: '8081'
+        mode: http
+        options:
+        - cookie A check
+      balance: round_robin
+      options:
+      - option httpclose
+      - option forwardfor
+      - cookie JSESSIONID prefix
+    - name: backend-443
+      bind:
+        port: '8081'
+        mode: http
+        options:
+        - cookie A check
+      balance: round_robin
+      options:
+      - option httpclose
+      - option forwardfor
+      - cookie JSESSIONID prefix

--- a/samples/apps/postgres.yml
+++ b/samples/apps/postgres.yml
@@ -1,16 +1,14 @@
-#
+---
 service:
   name: postgres
   network: bridge
-  image: "postgres:14"
-  ports:
-    - 5432:5432:tcp:round_robin
+  image: postgres:14
   environment:
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
     POSTGRES_DB: postgres
   volumes:
-    - docker://postgresql_14_data:/var/lib/postgresql/data
+  - docker://postgresql_14_data:/var/lib/postgresql/data
   restart: always
   resources:
     max_replicas: 1
@@ -18,5 +16,17 @@ service:
   limits:
     cpu: 1000m
     ram: 1Gi
-
-
+  ingress:
+    frontend:
+    - name: frontend-5432
+      options: []
+      bind:
+        port: '5432'
+        mode: tcp
+      default_backend: backend-5432
+    backend:
+    - name: backend-5432
+      bind:
+        port: '5432'
+        mode: tcp
+      balance: round_robin

--- a/samples/apps/rabbitmq.yml
+++ b/samples/apps/rabbitmq.yml
@@ -1,19 +1,46 @@
-#
+---
 service:
   name: rabbitmq
   image: rabbitmq:3-management-alpine
-  network: bridge # docker network
-  ports:
-    - 5672:5672:tcp:round_robin
-    - 80:15672:http:round_robin
+  network: bridge
   resources:
     max_replicas: 1
     min_replicas: 1
   volumes:
-    - docker://mkit_rabbitmq_data:/var/lib/rabbitmq
-    - docker://mkit_rabbitmq_logs:/var/log/rabbitmq
+  - docker://mkit_rabbitmq_data:/var/lib/rabbitmq
+  - docker://mkit_rabbitmq_logs:/var/log/rabbitmq
   environment:
     RABBITMQ_DEFAULT_USER: admin
     RABBITMQ_DEFAULT_PASS: admin
     RABBITMQ_DEFAULT_VHOST: mkit
-
+  ingress:
+    frontend:
+    - name: frontend-5672
+      options: []
+      bind:
+        port: '5672'
+        mode: tcp
+      default_backend: backend-5672
+    - name: frontend-80
+      options: []
+      bind:
+        port: '80'
+        mode: http
+      default_backend: backend-80
+    backend:
+    - name: backend-5672
+      bind:
+        port: '5672'
+        mode: tcp
+      balance: round_robin
+    - name: backend-80
+      bind:
+        port: '15672'
+        mode: http
+        options:
+        - cookie A check
+      balance: round_robin
+      options:
+      - option httpclose
+      - option forwardfor
+      - cookie JSESSIONID prefix

--- a/samples/apps/redis-sentinel.yml
+++ b/samples/apps/redis-sentinel.yml
@@ -1,11 +1,21 @@
-#
+---
 service:
   name: redis-sentinel
   image: bitnami/redis-sentinel:latest
   network: bridge
-  ports:
-    - 26379:26379:tcp:round_robin
   environment:
     REDIS_MASTER_HOST: redis
-
-
+  ingress:
+    frontend:
+    - name: frontend-26379
+      options: []
+      bind:
+        port: '26379'
+        mode: tcp
+      default_backend: backend-26379
+    backend:
+    - name: backend-26379
+      bind:
+        port: '26379'
+        mode: tcp
+      balance: round_robin

--- a/samples/apps/redis.yml
+++ b/samples/apps/redis.yml
@@ -1,9 +1,19 @@
-#
+---
 service:
   name: redis
   image: redis:4.0-alpine
   network: bridge
-  ports:
-    - 6379:6379:tcp:round_robin
-
-
+  ingress:
+    frontend:
+    - name: frontend-6379
+      options: []
+      bind:
+        port: '6379'
+        mode: tcp
+      default_backend: backend-6379
+    backend:
+    - name: backend-6379
+      bind:
+        port: '6379'
+        mode: tcp
+      balance: round_robin


### PR DESCRIPTION
This PR adds a new ingress configuration that replaces the [port] list. I needed more `haproxy` configuration options and a line just won't scale, so a new configuration was added.

A new `sample` service configuration is added - `httpbin` - as example for the new schema.

Tools to migrate old format service file is also included via `mkit` client:
```
mkit migrate <service_old_format.yml>
``` 
The current ones will be migrated at boot time.

This PR also makes a small refactor on internal saga and on docker listener services.

