### PR TITLE
fix: to_yaml line_width issue

### DIFF
--- a/lib/mkit/app/controllers/services_controller.rb
+++ b/lib/mkit/app/controllers/services_controller.rb
@@ -30,7 +30,7 @@ class ServicesController < MKIt::Server
   get '/services/:id' do
     srv = find_by_id_or_name
     resp = if params[:format] == 'yaml'
-             srv.to_h({details: params[:details] == 'true'}).to_yaml
+             srv.to_h({details: params[:details] == 'true'}).to_yaml(line_width: -1)
            elsif params[:format] == 'json'
              JSON.pretty_generate(srv.to_h({details: params[:details] == 'true'}))
            else
@@ -107,7 +107,7 @@ class ServicesController < MKIt::Server
     if params[:file]
       tempfile = params[:file][:tempfile]
       yaml = YAML.safe_load(tempfile.read)
-      srv = migrate_service(yaml).to_yaml
+      srv = migrate_service(yaml).to_yaml(line_width: -1)
     end
     srv
   end

--- a/lib/mkit/version.rb
+++ b/lib/mkit/version.rb
@@ -1,4 +1,4 @@
 module MKIt
-  VERSION = "0.10.3"
+  VERSION = "0.10.4"
 end
 


### PR DESCRIPTION
* fix: when exporting configuration `to_yaml`, the default setting wraps the line at position 80. this is a problem for log command line. this commit sets the `line_width` to `-1` when exporting the  service configuration.