### PR TITLE
feat: introducing cpu and memory limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ service:
   resources:
     min_replicas: 1 # default value. Pods will be available on internal DNS as '<service_name>.internal'
     max_replicas: 1 # default value
+    limits:
+      cpu: 250m # cpu limit - 1000m represents 1 cpu core. minimum 10m. default is empty
+      memory: 250m # memory limit - default is empty
+      memory_swap: 250m # memory + swap limit - default is empty
   volumes:
     - docker://mkit_rabbitmq_data:/var/lib/rabbitmq # a docker volume - it will be created if it does not exists
     - /var/log/rabbitmq/logs:/var/log/rabbitmq # a local volume

--- a/db/migrate/008_create_resources.rb
+++ b/db/migrate/008_create_resources.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateResources < ActiveRecord::Migration[5.1]
+  def up
+    create_table :resources do |t|
+      t.string :service_id
+      t.string :version
+      t.integer :min_replicas, default: 1
+      t.integer :max_replicas, default: 1
+      t.string :cpu_limits
+      t.string :memory_limits
+      t.string :memory_swap_limits
+      t.timestamp :created_at
+      t.timestamp :updated_at
+    end
+  end
+end

--- a/db/migrate/009_migrate_resources.rb
+++ b/db/migrate/009_migrate_resources.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class MigrateResources < ActiveRecord::Migration[5.1]
+
+  #
+  # migrate the resource data from service
+  #
+  def up
+    Service.all.each do |service|
+      resource = Resource.new
+      resource.max_replicas = service.max_replicas
+      resource.min_replicas = service.min_replicas
+      service.resource = resource
+    end
+  end
+end

--- a/lib/mkit.rb
+++ b/lib/mkit.rb
@@ -147,14 +147,17 @@ module MKIt
     end
     # daemontools would eventually start haproxy; systemd does not.
     # so, restart here.
-    restart_proxy = Thread.new do
-      MKItLogger.debug 'restarting proxy...'
-      MKIt::HAProxy.stop
-      sleep 10
-      MKIt::HAProxy.restart
-      MKItLogger.debug 'restarting proxy done.'
+    Thread.new do
+      begin
+        MKItLogger.debug 'restarting proxy...'
+        MKIt::HAProxy.stop
+        sleep 10
+        MKIt::HAProxy.restart
+        MKItLogger.debug 'restarting proxy done.'
+      rescue => e
+        MKItLogger.error "Error in restart_proxy thread: #{e.message}"
+      end
     end
-    restart_proxy.run
   end
 
   def self.startup(options: {})

--- a/lib/mkit/app/helpers/docker_helper.rb
+++ b/lib/mkit/app/helpers/docker_helper.rb
@@ -87,5 +87,20 @@ module MKIt
       x = MKIt::CmdRunner.run("docker volume inspect #{volume_name}")
       JSON.parse(x).first
     end
+
+    ##
+    # cpu limits
+    def to_docker_cpu_limit(k8s_cpu_limits)
+      if k8s_cpu_limits.nil?
+        nil
+      else
+        cpu_limit = k8s_cpu_limits.to_s
+        if cpu_limit.include?('m')
+          cpu_limit = cpu_limit.delete_suffix('m')
+          cpu_limit = (cpu_limit.to_f / 1000).to_s
+        end
+        cpu_limit
+      end
+    end
   end
 end

--- a/lib/mkit/app/model/resource.rb
+++ b/lib/mkit/app/model/resource.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Resource < ActiveRecord::Base
+  belongs_to :service
+
+  def self.create(yaml)
+    resource = Resource.new
+    if yaml.nil?
+      resource.max_replicas = 1
+      resource.min_replicas = 1
+    else
+      validate(yaml)
+      if yaml["min_replicas"]
+        resource.min_replicas = yaml["min_replicas"]
+      else
+        resource.min_replicas = 1
+      end
+      if yaml["max_replicas"]
+        resource.max_replicas = yaml["max_replicas"]
+      else
+        resource.max_replicas = resource.min_replicas
+      end
+      resource.cpu_limits = yaml["limits"]["cpu"] if yaml["limits"] && yaml["limits"]["cpu"]
+      resource.memory_limits = yaml["limits"]["memory"] if yaml["limits"] && yaml["limits"]["memory"]
+      resource.memory_swap_limits = yaml["limits"]["memory_swap"] if yaml["limits"] && yaml["limits"]["memory_swap"]
+    end
+    resource
+  end
+
+  def self.validate(yaml)
+    unless yaml.nil?
+      raise_bad_configuration "resource min_replicas must be bigger or equal than 1" if yaml["min_replicas"] && yaml["min_replicas"] < 1
+      raise_bad_configuration "resource max_replicas must be bigger or equal than 1" if yaml["max_replicas"] && yaml["max_replicas"] < 1
+      if yaml["min_replicas"] && yaml["max_replicas"]
+        raise_bad_configuration "resource max_replicas must be bigger or equal than min_replicas" if yaml["min_replicas"] > yaml["max_replicas"]
+      end
+    end
+    # validate limits
+    unless yaml.nil? || yaml["limits"].nil?
+      resources = yaml["limits"]
+      raise_bad_configuration "resource cpu limits must match '\\d+m'" if resources["cpu"] && resources["cpu"] !~ /\d+m$/
+      raise_bad_configuration "resource memory limits must match '\\d+m'" if resources["memory"] && resources["memory"] !~ /\d+m$/
+      raise_bad_configuration "resource memory_swap limits must match '\\d+m'" if resources["memory_swap"] && resources["memory_swap"] !~ /\d+m$/
+    end
+    true
+  end
+
+  def to_h(options = {})
+    hash = {
+      min_replicas: self.min_replicas,
+      max_replicas: self.max_replicas
+    }
+    if self.cpu_limits || self.memory_limits || self.memory_swap_limits
+      hash[:limits] = {}
+      hash[:limits][:cpu] = self.cpu_limits if self.cpu_limits
+      hash[:limits][:memory] = self.memory_limits if self.memory_limits
+      hash[:limits][:memory_swap] = self.memory_swap_limits if self.memory_swap_limits
+    end
+    hash.remove_symbols_from_keys
+  end
+end

--- a/lib/mkit/app/templates/docker/docker_run.sh.erb
+++ b/lib/mkit/app/templates/docker/docker_run.sh.erb
@@ -1,1 +1,10 @@
-docker run -d --name <%=name%>  <%service.service_config&.select{ |x| x.ctype == MKIt::CType::ENVIRONMENT.to_s }.each { |env|%><%=" -e #{env.key}=\"#{env.value}\""%><%}%> <%service.volume&.each { |vol|%><%=" -v \"#{vol.name}:#{vol.path}\""%><%}%>  --network <%=service.pods_network%> --dns <%=service.my_dns%> <%=service.image%> <%=service.command unless service.command.nil?%>
+docker run -d --name <%=name%>  \
+  <%service.service_config&.select{ |x| x.ctype == MKIt::CType::ENVIRONMENT.to_s }.each { |env|%><%=" -e #{env.key}=\"#{env.value}\""%><%}%> \
+  <%service.volume&.each { |vol|%><%=" -v \"#{vol.name}:#{vol.path}\""%><%}%> \
+  --network <%=service.pods_network%> \
+  --dns <%=service.my_dns%> \
+  <%="--cpus #{to_docker_cpu_limit(service.resource.cpu_limits)}" unless service.resource.cpu_limits.nil?%> \
+  <%="--memory #{service.resource.memory_limits}" unless service.resource.memory_limits.nil?%> \
+  <%="--memory-swap #{service.resource.memory_swap_limits}" unless service.resource.memory_swap_limits.nil?%> \
+  <%=service.image%> \
+  <%=service.command unless service.command.nil?%>

--- a/lib/mkit/cmd_runner.rb
+++ b/lib/mkit/cmd_runner.rb
@@ -19,7 +19,7 @@ module MKIt
       rescue PTY::ChildExited
         # nothing
       end
-      raise CmdRunnerException.new("command '#{cmd[0..30]}...' returned an error response") if !$?.nil? && $?.exitstatus != 0
+      raise CmdRunnerException.new("command '#{cmd[0..30]}...' returned an error [#{result}] (#{$?})") if !$?.nil? && $?.exitstatus != 0
       result
     end
   end

--- a/lib/mkit/version.rb
+++ b/lib/mkit/version.rb
@@ -1,4 +1,4 @@
 module MKIt
-  VERSION = "0.10.4"
+  VERSION = "0.10.5"
 end
 

--- a/samples/apps/swiss-army-knife.yml
+++ b/samples/apps/swiss-army-knife.yml
@@ -1,26 +1,14 @@
 ---
 service:
-  name: httpbin
-  image: mccutchen/go-httpbin
-  command: 
+  name: swiss-army-knife
+  image: leodotcloud/swiss-army-knife
+  command: swiss-army-knife
   network: bridge
   ingress:
     frontend:
-      - name: http-in-ssl
-        options:
-          - option httpclose
-          - option forwardfor
-        bind:
-          port: 443
-          mode: http
-          ssl: true
-          options:
-            - accept-proxy
-            - transparent
-            - defer-accept
-        default_backend: server
       - name: http-in
         options:
+          - option httpclose
           - option forwardfor
         bind:
           port: 80
@@ -41,9 +29,9 @@ service:
     min_replicas: 1
     max_replicas: 1
     limits:
-      cpu: 250m
-      memory: 250m
-      memory_swap: 250m
+      cpu: 500m
+      memory: 512m
+      memory_swap: 512m
   volumes: []
   environment:
     LOG4J_LEVEL: WARN


### PR DESCRIPTION
* feat: introducing support for container cpu and memory limits. currently:
   * `cpus`
   * `memory`
   * `memory-swap`

```
...
  resources:
    min_replicas: 1
    max_replicas: 1
    limits:
      cpu: 500m
      memory: 512m
      memory_swap: 512m
...
```

* fix: haproxy start after reboot
  * on system reboot, internal interfaces are not created when `systemd` tries to start `haproxy`. a small fix was added to restart `haproxy` at  the end of the `mkit` startup process but it fails to start it nevertheless.
    this approach starts `haproxy` async, giving it time to the system to startup so all the requirements are met to startup haproxy.
